### PR TITLE
PSI tree reference

### DIFF
--- a/PSI/Reference/RegExp/Manipulation.md
+++ b/PSI/Reference/RegExp/Manipulation.md
@@ -1,0 +1,1 @@
+# Manipulating the Tree

--- a/PSI/Reference/RegExp/Navigators.md
+++ b/PSI/Reference/RegExp/Navigators.md
@@ -1,0 +1,227 @@
+# Navigators
+
+<!-- Index A - Z (auto-generated. Remove this line if manually adding/removing entries) -->
+
+<!-- toc -->
+<!-- toc stop -->
+
+## C
+
+### ConcatenationRegularExpressionNavigator
+
+<!-- Begin ConcatenationRegularExpressionNavigator -->
+
+```cs
+public static class ConcatenationRegularExpressionNavigator
+{
+  public static IConcatenationRegularExpression GetByUnitRegularExpression(IUnitRegularExpression param);
+}
+```
+
+<!-- End ConcatenationRegularExpressionNavigator -->
+
+## G
+
+### GroupNameNavigator
+
+<!-- Begin GroupNameNavigator -->
+
+```cs
+public static class GroupNameNavigator
+{
+  public static IGroupName GetByName(IName param);
+  public static IGroupName GetBySecondaryName(IName param);
+}
+```
+
+<!-- End GroupNameNavigator -->
+
+## N
+
+### NamedBackreferenceNavigator
+
+<!-- Begin NamedBackreferenceNavigator -->
+
+```cs
+public static class NamedBackreferenceNavigator
+{
+  public static INamedBackreference GetByName(IName param);
+}
+```
+
+<!-- End NamedBackreferenceNavigator -->
+
+### NamedBlockNavigator
+
+<!-- Begin NamedBlockNavigator -->
+
+```cs
+public static class NamedBlockNavigator
+{
+  public static INamedBlock GetByName(IName param);
+}
+```
+
+<!-- End NamedBlockNavigator -->
+
+### NamedGroupNavigator
+
+<!-- Begin NamedGroupNavigator -->
+
+```cs
+public static class NamedGroupNavigator
+{
+  public static INamedGroup GetByGroupName(IGroupName param);
+  public static INamedGroup GetByRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End NamedGroupNavigator -->
+
+### NestedSetNavigator
+
+<!-- Begin NestedSetNavigator -->
+
+```cs
+public static class NestedSetNavigator
+{
+  public static INestedSet GetByInnerSet(ISet param);
+}
+```
+
+<!-- End NestedSetNavigator -->
+
+### NumericQuantifierNavigator
+
+<!-- Begin NumericQuantifierNavigator -->
+
+```cs
+public static class NumericQuantifierNavigator
+{
+  public static INumericQuantifier GetByNumber(INumber param);
+  public static INumericQuantifier GetBySecondaryNumber(INumber param);
+}
+```
+
+<!-- End NumericQuantifierNavigator -->
+
+## O
+
+### OptionGroupNavigator
+
+<!-- Begin OptionGroupNavigator -->
+
+```cs
+public static class OptionGroupNavigator
+{
+  public static IOptionGroup GetByRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End OptionGroupNavigator -->
+
+## P
+
+### PrefixGroupNavigator
+
+<!-- Begin PrefixGroupNavigator -->
+
+```cs
+public static class PrefixGroupNavigator
+{
+  public static IPrefixGroup GetByPrefix(IGroupPrefix param);
+  public static IPrefixGroup GetByRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End PrefixGroupNavigator -->
+
+## Q
+
+### QuantifiableRegularExpressionNavigator
+
+<!-- Begin QuantifiableRegularExpressionNavigator -->
+
+```cs
+public static class QuantifiableRegularExpressionNavigator
+{
+  public static IQuantifiableRegularExpression GetByOwner(IQuantifierOwner param);
+  public static IQuantifiableRegularExpression GetByQuantifier(IQuantifier param);
+}
+```
+
+<!-- End QuantifiableRegularExpressionNavigator -->
+
+### QuantifierNavigator
+
+<!-- Begin QuantifierNavigator -->
+
+```cs
+public static class QuantifierNavigator
+{
+  public static IQuantifier GetByNumeric(INumericQuantifier param);
+}
+```
+
+<!-- End QuantifierNavigator -->
+
+## R
+
+### RegularExpressionFileNavigator
+
+<!-- Begin RegularExpressionFileNavigator -->
+
+```cs
+public static class RegularExpressionFileNavigator
+{
+  public static IRegularExpressionFile GetByRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End RegularExpressionFileNavigator -->
+
+### RegularExpressionNavigator
+
+<!-- Begin RegularExpressionNavigator -->
+
+```cs
+public static class RegularExpressionNavigator
+{
+  public static IRegularExpression GetByConcatenationRegularExpression(IConcatenationRegularExpression param);
+}
+```
+
+<!-- End RegularExpressionNavigator -->
+
+## S
+
+### SetNavigator
+
+<!-- Begin SetNavigator -->
+
+```cs
+public static class SetNavigator
+{
+  public static ISet GetByBody(ISetBody param);
+}
+```
+
+<!-- End SetNavigator -->
+
+### SetRangeNavigator
+
+<!-- Begin SetRangeNavigator -->
+
+```cs
+public static class SetRangeNavigator
+{
+  public static ISetRange GetByMax(ISetRangeItem param);
+  public static ISetRange GetByMin(ISetRangeItem param);
+}
+```
+
+<!-- End SetRangeNavigator -->
+
+
+
+

--- a/PSI/Reference/RegExp/Navigators.md
+++ b/PSI/Reference/RegExp/Navigators.md
@@ -18,6 +18,8 @@ public static class ConcatenationRegularExpressionNavigator
 }
 ```
 
+* See also: [IConcatenationRegularExpression](TreeNodesA-N.md#iconcatenationregularexpression), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
+
 <!-- End ConcatenationRegularExpressionNavigator -->
 
 ## G
@@ -34,6 +36,8 @@ public static class GroupNameNavigator
 }
 ```
 
+* See also: [IGroupName](TreeNodesA-N.md#igroupname), [IName](TreeNodesA-N.md#iname)
+
 <!-- End GroupNameNavigator -->
 
 ## N
@@ -49,6 +53,8 @@ public static class NamedBackreferenceNavigator
 }
 ```
 
+* See also: [IName](TreeNodesA-N.md#iname), [INamedBackreference](TreeNodesA-N.md#inamedbackreference)
+
 <!-- End NamedBackreferenceNavigator -->
 
 ### NamedBlockNavigator
@@ -61,6 +67,8 @@ public static class NamedBlockNavigator
   public static INamedBlock GetByName(IName param);
 }
 ```
+
+* See also: [IName](TreeNodesA-N.md#iname), [INamedBlock](TreeNodesA-N.md#inamedblock)
 
 <!-- End NamedBlockNavigator -->
 
@@ -76,6 +84,8 @@ public static class NamedGroupNavigator
 }
 ```
 
+* See also: [IGroupName](TreeNodesA-N.md#igroupname), [INamedGroup](TreeNodesA-N.md#inamedgroup), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End NamedGroupNavigator -->
 
 ### NestedSetNavigator
@@ -88,6 +98,8 @@ public static class NestedSetNavigator
   public static INestedSet GetByInnerSet(ISet param);
 }
 ```
+
+* See also: [INestedSet](TreeNodesA-N.md#inestedset), [ISet](TreeNodesO-Z.md#iset)
 
 <!-- End NestedSetNavigator -->
 
@@ -103,6 +115,8 @@ public static class NumericQuantifierNavigator
 }
 ```
 
+* See also: [INumber](TreeNodesA-N.md#inumber), [INumericQuantifier](TreeNodesA-N.md#inumericquantifier)
+
 <!-- End NumericQuantifierNavigator -->
 
 ## O
@@ -117,6 +131,8 @@ public static class OptionGroupNavigator
   public static IOptionGroup GetByRegularExpression(IRegularExpression param);
 }
 ```
+
+* See also: [IOptionGroup](TreeNodesO-Z.md#ioptiongroup), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
 
 <!-- End OptionGroupNavigator -->
 
@@ -134,6 +150,8 @@ public static class PrefixGroupNavigator
 }
 ```
 
+* See also: [IGroupPrefix](TreeNodesA-N.md#igroupprefix), [IPrefixGroup](TreeNodesO-Z.md#iprefixgroup), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End PrefixGroupNavigator -->
 
 ## Q
@@ -150,6 +168,8 @@ public static class QuantifiableRegularExpressionNavigator
 }
 ```
 
+* See also: [IQuantifiableRegularExpression](TreeNodesO-Z.md#iquantifiableregularexpression), [IQuantifier](TreeNodesO-Z.md#iquantifier), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner)
+
 <!-- End QuantifiableRegularExpressionNavigator -->
 
 ### QuantifierNavigator
@@ -162,6 +182,8 @@ public static class QuantifierNavigator
   public static IQuantifier GetByNumeric(INumericQuantifier param);
 }
 ```
+
+* See also: [INumericQuantifier](TreeNodesA-N.md#inumericquantifier), [IQuantifier](TreeNodesO-Z.md#iquantifier)
 
 <!-- End QuantifierNavigator -->
 
@@ -178,6 +200,8 @@ public static class RegularExpressionFileNavigator
 }
 ```
 
+* See also: [IRegularExpression](TreeNodesO-Z.md#iregularexpression), [IRegularExpressionFile](TreeNodesO-Z.md#iregularexpressionfile)
+
 <!-- End RegularExpressionFileNavigator -->
 
 ### RegularExpressionNavigator
@@ -190,6 +214,8 @@ public static class RegularExpressionNavigator
   public static IRegularExpression GetByConcatenationRegularExpression(IConcatenationRegularExpression param);
 }
 ```
+
+* See also: [IConcatenationRegularExpression](TreeNodesA-N.md#iconcatenationregularexpression), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
 
 <!-- End RegularExpressionNavigator -->
 
@@ -206,6 +232,8 @@ public static class SetNavigator
 }
 ```
 
+* See also: [ISet](TreeNodesO-Z.md#iset), [ISetBody](TreeNodesO-Z.md#isetbody)
+
 <!-- End SetNavigator -->
 
 ### SetRangeNavigator
@@ -220,7 +248,10 @@ public static class SetRangeNavigator
 }
 ```
 
+* See also: [ISetRange](TreeNodesO-Z.md#isetrange), [ISetRangeItem](TreeNodesO-Z.md#isetrangeitem)
+
 <!-- End SetRangeNavigator -->
+
 
 
 

--- a/PSI/Reference/RegExp/Overview.md
+++ b/PSI/Reference/RegExp/Overview.md
@@ -1,0 +1,1 @@
+# Overview

--- a/PSI/Reference/RegExp/TreeNodesA-N.md
+++ b/PSI/Reference/RegExp/TreeNodesA-N.md
@@ -1,0 +1,361 @@
+# TreeNodes A - N
+
+<!-- Index A - N (auto-generated. Remove this line if manually adding/removing entries) -->
+
+<!-- toc -->
+<!-- toc stop -->
+
+## A
+
+### IAlternationGroup
+
+<!-- Begin IAlternationGroup -->
+
+```cs
+public interface IAlternationGroup :
+  IGroup,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode AltLParenth { get; }
+  ITokenNode AltRParenth { get; }
+  ITokenNode LongPrefix { get; }
+  ITokenNode Pipe { get; }
+  ITokenNode Prefix { get; }
+  ITokenNode QuestionSign { get; }
+}
+```
+
+<!-- End IAlternationGroup -->
+
+### IAnchor
+
+<!-- Begin IAnchor -->
+
+```cs
+public interface IAnchor :
+  IUnitRegularExpression,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IAnchor -->
+
+## B
+
+### IBorderAnchor
+
+<!-- Begin IBorderAnchor -->
+
+```cs
+public interface IBorderAnchor :
+  IAnchor,
+  IUnitRegularExpression,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IBorderAnchor -->
+
+### IBracketCharacter
+
+<!-- Begin IBracketCharacter -->
+
+```cs
+public interface IBracketCharacter :
+  ICharacter,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IBracketCharacter -->
+
+## C
+
+### ICharacter
+
+<!-- Begin ICharacter -->
+
+```cs
+public interface ICharacter :
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ICharacter -->
+
+### IConcatenationRegularExpression
+
+<!-- Begin IConcatenationRegularExpression -->
+
+```cs
+public interface IConcatenationRegularExpression :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  TreeNodeCollection<IUnitRegularExpression> UnitRegularExpressions { get; }
+  TreeNodeEnumerable<IUnitRegularExpression> UnitRegularExpressionsEnumerable { get; }
+}
+```
+
+<!-- End IConcatenationRegularExpression -->
+
+
+## E
+
+### IEndAnchor
+
+<!-- Begin IEndAnchor -->
+
+```cs
+public interface IEndAnchor :
+  IAnchor,
+  IUnitRegularExpression,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IEndAnchor -->
+
+### IEscapeCharacter
+
+<!-- Begin IEscapeCharacter -->
+
+```cs
+public interface IEscapeCharacter :
+  ICharacter,
+  IQuantifierOwner,
+  ISetBodyCharacter,
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IEscapeCharacter -->
+
+## G
+
+### IGroup
+
+<!-- Begin IGroup -->
+
+```cs
+public interface IGroup :
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode LParenth { get; }
+  ITokenNode RParenth { get; }
+}
+```
+
+<!-- End IGroup -->
+
+### IGroupName
+
+<!-- Begin IGroupName -->
+
+```cs
+public interface IGroupName :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Dash { get; }
+  ITokenNode Gt { get; }
+  ITokenNode Lt { get; }
+  IName Name { get; }
+  IName SecondaryName { get; }
+
+  IName SetName(IName param);
+  IName SetSecondaryName(IName param);
+}
+```
+
+<!-- End IGroupName -->
+
+### IGroupPrefix
+
+<!-- Begin IGroupPrefix -->
+
+```cs
+public interface IGroupPrefix :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode LongPrefix { get; }
+  ITokenNode Lt { get; }
+  ITokenNode Prefix { get; }
+}
+```
+
+<!-- End IGroupPrefix -->
+
+
+## I
+
+### IInvalidCharacter
+
+<!-- Begin IInvalidCharacter -->
+
+```cs
+public interface IInvalidCharacter :
+  IErrorElement,
+  ICharacter,
+  IQuantifierOwner,
+  ISetBodyCharacter,
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IInvalidCharacter -->
+
+## N
+
+### IName
+
+<!-- Begin IName -->
+
+```cs
+public interface IName :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IName -->
+
+### INamedBackreference
+
+<!-- Begin INamedBackreference -->
+
+```cs
+public interface INamedBackreference :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Gt { get; }
+  ITokenNode Lt { get; }
+  IName Name { get; }
+
+  IName SetName(IName param);
+}
+```
+
+<!-- End INamedBackreference -->
+
+### INamedBlock
+
+<!-- Begin INamedBlock -->
+
+```cs
+public interface INamedBlock :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode LBrace { get; }
+  IName Name { get; }
+  ITokenNode RBrace { get; }
+
+  IName SetName(IName param);
+}
+```
+
+<!-- End INamedBlock -->
+
+### INamedGroup
+
+<!-- Begin INamedGroup -->
+
+```cs
+public interface INamedGroup :
+  IGroup,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  IGroupName GroupName { get; }
+  ITokenNode QuestionSign { get; }
+  IRegularExpression RegularExpression { get; }
+
+  IGroupName SetGroupName(IGroupName param);
+  IRegularExpression SetRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End INamedGroup -->
+
+### INestedSet
+
+<!-- Begin INestedSet -->
+
+```cs
+public interface INestedSet :
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Dash { get; }
+  ISet InnerSet { get; }
+
+  ISet SetInnerSet(ISet param);
+}
+```
+
+<!-- End INestedSet -->
+
+### INumber
+
+<!-- Begin INumber -->
+
+```cs
+public interface INumber :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End INumber -->
+
+### INumericQuantifier
+
+<!-- Begin INumericQuantifier -->
+
+```cs
+public interface INumericQuantifier :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Comma { get; }
+  ITokenNode LBrace { get; }
+  INumber Number { get; }
+  ITokenNode RBrace { get; }
+  INumber SecondaryNumber { get; }
+
+  INumber SetNumber(INumber param);
+  INumber SetSecondaryNumber(INumber param);
+}
+```
+
+<!-- End INumericQuantifier -->
+

--- a/PSI/Reference/RegExp/TreeNodesA-N.md
+++ b/PSI/Reference/RegExp/TreeNodesA-N.md
@@ -27,6 +27,8 @@ public interface IAlternationGroup :
 }
 ```
 
+* See also: [IGroup](TreeNodesA-N.md#igroup), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End IAlternationGroup -->
 
 ### IAnchor
@@ -41,6 +43,8 @@ public interface IAnchor :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
 
 <!-- End IAnchor -->
 
@@ -60,6 +64,8 @@ public interface IBorderAnchor :
 }
 ```
 
+* See also: [IAnchor](TreeNodesA-N.md#ianchor), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
+
 <!-- End IBorderAnchor -->
 
 ### IBracketCharacter
@@ -75,6 +81,8 @@ public interface IBracketCharacter :
 {
 }
 ```
+
+* See also: [ICharacter](TreeNodesA-N.md#icharacter), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IBracketCharacter -->
 
@@ -93,6 +101,8 @@ public interface ICharacter :
 }
 ```
 
+* See also: [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End ICharacter -->
 
 ### IConcatenationRegularExpression
@@ -108,6 +118,8 @@ public interface IConcatenationRegularExpression :
   TreeNodeEnumerable<IUnitRegularExpression> UnitRegularExpressionsEnumerable { get; }
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
 
 <!-- End IConcatenationRegularExpression -->
 
@@ -128,6 +140,8 @@ public interface IEndAnchor :
 }
 ```
 
+* See also: [IAnchor](TreeNodesA-N.md#ianchor), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
+
 <!-- End IEndAnchor -->
 
 ### IEscapeCharacter
@@ -145,6 +159,8 @@ public interface IEscapeCharacter :
 {
 }
 ```
+
+* See also: [ICharacter](TreeNodesA-N.md#icharacter), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyCharacter](TreeNodesO-Z.md#isetbodycharacter), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
 
 <!-- End IEscapeCharacter -->
 
@@ -164,6 +180,8 @@ public interface IGroup :
   ITokenNode RParenth { get; }
 }
 ```
+
+* See also: [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IGroup -->
 
@@ -187,6 +205,8 @@ public interface IGroupName :
 }
 ```
 
+* See also: [IName](TreeNodesA-N.md#iname), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End IGroupName -->
 
 ### IGroupPrefix
@@ -203,6 +223,8 @@ public interface IGroupPrefix :
   ITokenNode Prefix { get; }
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IGroupPrefix -->
 
@@ -226,6 +248,8 @@ public interface IInvalidCharacter :
 }
 ```
 
+* See also: [ICharacter](TreeNodesA-N.md#icharacter), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyCharacter](TreeNodesO-Z.md#isetbodycharacter), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
+
 <!-- End IInvalidCharacter -->
 
 ## N
@@ -241,6 +265,8 @@ public interface IName :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IName -->
 
@@ -261,6 +287,8 @@ public interface INamedBackreference :
 }
 ```
 
+* See also: [IName](TreeNodesA-N.md#iname), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End INamedBackreference -->
 
 ### INamedBlock
@@ -279,6 +307,8 @@ public interface INamedBlock :
   IName SetName(IName param);
 }
 ```
+
+* See also: [IName](TreeNodesA-N.md#iname), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End INamedBlock -->
 
@@ -302,6 +332,8 @@ public interface INamedGroup :
 }
 ```
 
+* See also: [IGroup](TreeNodesA-N.md#igroup), [IGroupName](TreeNodesA-N.md#igroupname), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End INamedGroup -->
 
 ### INestedSet
@@ -321,6 +353,8 @@ public interface INestedSet :
 }
 ```
 
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISet](TreeNodesO-Z.md#iset), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
+
 <!-- End INestedSet -->
 
 ### INumber
@@ -334,6 +368,8 @@ public interface INumber :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End INumber -->
 
@@ -356,6 +392,8 @@ public interface INumericQuantifier :
   INumber SetSecondaryNumber(INumber param);
 }
 ```
+
+* See also: [INumber](TreeNodesA-N.md#inumber), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End INumericQuantifier -->
 

--- a/PSI/Reference/RegExp/TreeNodesO-Z.md
+++ b/PSI/Reference/RegExp/TreeNodesO-Z.md
@@ -29,6 +29,8 @@ public interface IOptionGroup :
 }
 ```
 
+* See also: [IGroup](TreeNodesA-N.md#igroup), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End IOptionGroup -->
 
 ## Q
@@ -53,6 +55,8 @@ public interface IPrefixGroup :
 }
 ```
 
+* See also: [IGroup](TreeNodesA-N.md#igroup), [IGroupPrefix](TreeNodesA-N.md#igroupprefix), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End IPrefixGroup -->
 
 ### IQuantifiableRegularExpression
@@ -72,6 +76,8 @@ public interface IQuantifiableRegularExpression :
   IQuantifier SetQuantifier(IQuantifier param);
 }
 ```
+
+* See also: [IQuantifier](TreeNodesO-Z.md#iquantifier), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
 
 <!-- End IQuantifiableRegularExpression -->
 
@@ -94,6 +100,8 @@ public interface IQuantifier :
 }
 ```
 
+* See also: [INumericQuantifier](TreeNodesA-N.md#inumericquantifier), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End IQuantifier -->
 
 ### IQuantifierOwner
@@ -107,6 +115,8 @@ public interface IQuantifierOwner :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IQuantifierOwner -->
 
@@ -124,6 +134,8 @@ public interface IRegExpTokenNode :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End IRegExpTokenNode -->
 
@@ -159,6 +171,8 @@ public interface IRegularCharacter :
 }
 ```
 
+* See also: [ICharacter](TreeNodesA-N.md#icharacter), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyCharacter](TreeNodesO-Z.md#isetbodycharacter), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
+
 <!-- End IRegularCharacter -->
 
 ### IRegularExpression
@@ -177,6 +191,8 @@ public interface IRegularExpression :
 }
 ```
 
+* See also: [IConcatenationRegularExpression](TreeNodesA-N.md#iconcatenationregularexpression), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
+
 <!-- End IRegularExpression -->
 
 ### IRegularExpressionFile
@@ -194,6 +210,8 @@ public interface IRegularExpressionFile :
   IRegularExpression SetRegularExpression(IRegularExpression param);
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
 
 <!-- End IRegularExpressionFile -->
 
@@ -218,6 +236,8 @@ public interface ISet :
 }
 ```
 
+* See also: [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBody](TreeNodesO-Z.md#isetbody)
+
 <!-- End ISet -->
 
 ### ISetBody
@@ -231,6 +251,8 @@ public interface ISetBody :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End ISetBody -->
 
@@ -247,6 +269,8 @@ public interface ISetBodyCharacter :
 }
 ```
 
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
+
 <!-- End ISetBodyCharacter -->
 
 ### ISetBodyItem
@@ -260,6 +284,8 @@ public interface ISetBodyItem :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End ISetBodyItem -->
 
@@ -276,6 +302,8 @@ public interface ISetCharacter :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyCharacter](TreeNodesO-Z.md#isetbodycharacter), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
 
 <!-- End ISetCharacter -->
 
@@ -298,6 +326,8 @@ public interface ISetRange :
 }
 ```
 
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem), [ISetRangeItem](TreeNodesO-Z.md#isetrangeitem)
+
 <!-- End ISetRange -->
 
 ### ISetRangeItem
@@ -311,6 +341,8 @@ public interface ISetRangeItem :
 {
 }
 ```
+
+* See also: [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode)
 
 <!-- End ISetRangeItem -->
 
@@ -331,6 +363,8 @@ public interface ISimpleGroup :
 }
 ```
 
+* See also: [IGroup](TreeNodesA-N.md#igroup), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IRegularExpression](TreeNodesO-Z.md#iregularexpression)
+
 <!-- End ISimpleGroup -->
 
 ### IStartAnchor
@@ -346,6 +380,8 @@ public interface IStartAnchor :
 {
 }
 ```
+
+* See also: [IAnchor](TreeNodesA-N.md#ianchor), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [IUnitRegularExpression](TreeNodesO-Z.md#iunitregularexpression)
 
 <!-- End IStartAnchor -->
 
@@ -365,7 +401,10 @@ public interface ISymbolCharacter :
 }
 ```
 
+* See also: [ICharacter](TreeNodesA-N.md#icharacter), [IQuantifierOwner](TreeNodesO-Z.md#iquantifierowner), [IRegExpTreeNode](TreeNodesO-Z.md#iregexptreenode), [ISetBodyCharacter](TreeNodesO-Z.md#isetbodycharacter), [ISetBodyItem](TreeNodesO-Z.md#isetbodyitem)
+
 <!-- End ISymbolCharacter -->
+
 
 
 

--- a/PSI/Reference/RegExp/TreeNodesO-Z.md
+++ b/PSI/Reference/RegExp/TreeNodesO-Z.md
@@ -1,0 +1,371 @@
+# TreeNodes O - Z
+
+<!-- Index O - Z (auto-generated. Remove this line if manually adding/removing entries) -->
+
+<!-- toc -->
+<!-- toc stop -->
+
+## O
+
+### IOptionGroup
+
+<!-- Begin IOptionGroup -->
+
+```cs
+public interface IOptionGroup :
+  IGroup,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Colon { get; }
+  ITokenNode Dash { get; }
+  TreeNodeCollection<ITokenNode> Options { get; }
+  TreeNodeEnumerable<ITokenNode> OptionsEnumerable { get; }
+  ITokenNode QuestionSign { get; }
+  IRegularExpression RegularExpression { get; }
+
+  IRegularExpression SetRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End IOptionGroup -->
+
+## Q
+
+### IPrefixGroup
+
+<!-- Begin IPrefixGroup -->
+
+```cs
+public interface IPrefixGroup :
+  IGroup,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  IGroupPrefix Prefix { get; }
+  ITokenNode QuestionSign { get; }
+  IRegularExpression RegularExpression { get; }
+
+  IGroupPrefix SetPrefix(IGroupPrefix param);
+  IRegularExpression SetRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End IPrefixGroup -->
+
+### IQuantifiableRegularExpression
+
+<!-- Begin IQuantifiableRegularExpression -->
+
+```cs
+public interface IQuantifiableRegularExpression :
+  IUnitRegularExpression,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  IQuantifierOwner Owner { get; }
+  IQuantifier Quantifier { get; }
+
+  IQuantifierOwner SetOwner(IQuantifierOwner param);
+  IQuantifier SetQuantifier(IQuantifier param);
+}
+```
+
+<!-- End IQuantifiableRegularExpression -->
+
+### IQuantifier
+
+<!-- Begin IQuantifier -->
+
+```cs
+public interface IQuantifier :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  INumericQuantifier Numeric { get; }
+  ITokenNode OptionalQuestion { get; }
+  ITokenNode Plus { get; }
+  ITokenNode Question { get; }
+  ITokenNode Star { get; }
+
+  INumericQuantifier SetNumeric(INumericQuantifier param);
+}
+```
+
+<!-- End IQuantifier -->
+
+### IQuantifierOwner
+
+<!-- Begin IQuantifierOwner -->
+
+```cs
+public interface IQuantifierOwner :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IQuantifierOwner -->
+
+## R
+
+### IRegExpTokenNode
+
+<!-- Begin IRegExpTokenNode -->
+
+```cs
+public interface IRegExpTokenNode :
+  IRegExpTreeNode,
+  ITokenNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IRegExpTokenNode -->
+
+### IRegExpTreeNode
+
+<!-- Begin IRegExpTreeNode -->
+
+```cs
+public interface IRegExpTreeNode :
+  ITreeNode
+{
+  void Accept(TreeNodeVisitor visitor);
+  void Accept<TContext>(TreeNodeVisitor<TContext> visitor, TContext context);
+  TReturn Accept<TContext, TReturn>(TreeNodeVisitor<TContext, TReturn> visitor, TContext context);
+}
+```
+
+<!-- End IRegExpTreeNode -->
+
+### IRegularCharacter
+
+<!-- Begin IRegularCharacter -->
+
+```cs
+public interface IRegularCharacter :
+  ICharacter,
+  IQuantifierOwner,
+  ISetBodyCharacter,
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IRegularCharacter -->
+
+### IRegularExpression
+
+<!-- Begin IRegularExpression -->
+
+```cs
+public interface IRegularExpression :
+  IRegExpTreeNode,
+  ITreeNode
+{
+  TreeNodeCollection<IConcatenationRegularExpression> ConcatenationRegularExpressions { get; }
+  TreeNodeEnumerable<IConcatenationRegularExpression> ConcatenationRegularExpressionsEnumerable { get; }
+  TreeNodeCollection<ITokenNode> Pipes { get; }
+  TreeNodeEnumerable<ITokenNode> PipesEnumerable { get; }
+}
+```
+
+<!-- End IRegularExpression -->
+
+### IRegularExpressionFile
+
+<!-- Begin IRegularExpressionFile -->
+
+```cs
+public interface IRegularExpressionFile :
+  IFile,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  IRegularExpression RegularExpression { get; }
+
+  IRegularExpression SetRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End IRegularExpressionFile -->
+
+## S
+
+### ISet
+
+<!-- Begin ISet -->
+
+```cs
+public interface ISet :
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ISetBody Body { get; }
+  ITokenNode LBracket { get; }
+  ITokenNode NegativeMark { get; }
+  ITokenNode RBracket { get; }
+
+  ISetBody SetBody(ISetBody param);
+}
+```
+
+<!-- End ISet -->
+
+### ISetBody
+
+<!-- Begin ISetBody -->
+
+```cs
+public interface ISetBody :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISetBody -->
+
+### ISetBodyCharacter
+
+<!-- Begin ISetBodyCharacter -->
+
+```cs
+public interface ISetBodyCharacter :
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISetBodyCharacter -->
+
+### ISetBodyItem
+
+<!-- Begin ISetBodyItem -->
+
+```cs
+public interface ISetBodyItem :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISetBodyItem -->
+
+### ISetCharacter
+
+<!-- Begin ISetCharacter -->
+
+```cs
+public interface ISetCharacter :
+  ISetBodyCharacter,
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISetCharacter -->
+
+### ISetRange
+
+<!-- Begin ISetRange -->
+
+```cs
+public interface ISetRange :
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  ITokenNode Dash { get; }
+  ISetRangeItem Max { get; }
+  ISetRangeItem Min { get; }
+
+  ISetRangeItem SetMax(ISetRangeItem param);
+  ISetRangeItem SetMin(ISetRangeItem param);
+}
+```
+
+<!-- End ISetRange -->
+
+### ISetRangeItem
+
+<!-- Begin ISetRangeItem -->
+
+```cs
+public interface ISetRangeItem :
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISetRangeItem -->
+
+### ISimpleGroup
+
+<!-- Begin ISimpleGroup -->
+
+```cs
+public interface ISimpleGroup :
+  IGroup,
+  IQuantifierOwner,
+  IRegExpTreeNode,
+  ITreeNode
+{
+  IRegularExpression RegularExpression { get; }
+
+  IRegularExpression SetRegularExpression(IRegularExpression param);
+}
+```
+
+<!-- End ISimpleGroup -->
+
+### IStartAnchor
+
+<!-- Begin IStartAnchor -->
+
+```cs
+public interface IStartAnchor :
+  IAnchor,
+  IUnitRegularExpression,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End IStartAnchor -->
+
+### ISymbolCharacter
+
+<!-- Begin ISymbolCharacter -->
+
+```cs
+public interface ISymbolCharacter :
+  ICharacter,
+  IQuantifierOwner,
+  ISetBodyCharacter,
+  ISetBodyItem,
+  IRegExpTreeNode,
+  ITreeNode
+{
+}
+```
+
+<!-- End ISymbolCharacter -->
+
+
+

--- a/PSI/Reference/readme.md
+++ b/PSI/Reference/readme.md
@@ -1,0 +1,100 @@
+# PSI Reference
+
+> **NOTE** This is not intended to be part of the compiled documentation!
+
+The files in these folders are generated semi-automatically. The PsiDocs2 program (not included in the repo yet, speak to Matt Ellis) will create and try to update the files. The process is:
+
+* The program uses Mono.Cecil to load the assembly containing the PSI implementation
+* It finds types:
+    * Tree nodes - all interfaces deriving from `ITreeNode`.
+    * Navigators - all classes with a name that ends `Navigator`.
+    * Utility classes and extension methods - all classes with a name ending `Util`, `Extension` or `Extensions`.
+    * Element factories - all types where the type name contains `ElementFactory` or `NodeFactory`, but doesn't end in `Extension` or `Extensions`.
+* It then creates or updates a type index file for each category of type.
+* Finally, any types listed in any file in the output directory are updated.
+
+## Generating type index files
+
+The program will first look to see if any files exist for the given category. For example, when creating the type index for tree nodes, the program will check to see if any `TreeNodes*.md` files already exist. This will pick up the type index if it's concatenated into a single file, or if it's split across multiple files.
+
+If the files do not exist, they are created. The types are grouped alphabetically (if all types are interfaces, the leading 'I' is stripped). There is some logic to try and balance the number of files with the size of the files, but by default, the types are grouped in files such as:
+
+* `TreeNodesA-D.md`
+* `TreeNodesE-H.md`
+* `TreeNodesI-L.md`
+* `TreeNodesM-P.md`
+* `TreeNodesQ-T.md`
+* `TreeNodesU-Z.md`
+
+The file is initially created as "auto-indexed", which means that when it's updated with a new version of the PSI, any missing types are automatically added in the appropriate place. This is done by adding the following HTML comment to the top of the file:
+
+```
+<!-- Index A - D (auto-generated. Remove this line if manually adding/removing entries) -->
+```
+
+The file then adds the `<!-- toc -->` table of contents macro used by the [gitbook-plugin-toc](https://github.com/whzhyh/gitbook-plugin-toc) GitBook plugin.
+
+Each letter in the index then gets a new heading, and each type definition is added in between the special HTML comments `<!-- Begin {TypeName} -->` and `<!-- End {TypeName} -->`. These comments are used when updating the content.
+
+## Updating type index files
+
+If the index files already exist, they need to be updated, in order to ensure that they contain only the required types, and that the type definition itself is up to date. Each file is processed, looking for the auto-index comment (see above). If this comment is found, the letters after the word "Index" are used to indicate that this file contains types beginning with those letters (again, interaces have the leading 'I' removed, only if *all* types are interfaces, e.g. tree nodes).
+
+If the auto-index comment is missing, the app will create a new file called `{Type}-missing.md` (e.g. `TreeNodes-missing.md`). This file will contain a list of types that are missing from the other files. They will be correctly formatted, and should be manually copy-and-pasted to the appropriate place.
+
+Each file is now processed. Auto-indexed files will automatically have new types added, and any types that no longer exist are removed, even for non-auto-indexed files. When adding a type, a new section is added, with header, HTML comments and the type definition. When removing a type, the whole section is removed, including header, HTML comments, type definitions and *any* other content up to the next section. Please make sure to review changes before committing!
+
+## Updating content
+
+Finally, the program will update the content in all `*.md` files in the output directory, not just the index files created. This includes hand-crafted files such as `Overview.md`. It will process all `*.md` files in the output directory and look for specially formatted HTML comments, that gives the name of the type that should be output between the comments.
+
+For example, the content:
+
+```
+<!-- Begin ICSharpTreeNode -->
+<!-- End ICSharpTreeNode -->
+```
+
+will be replaced with:
+
+```
+<!-- Begin ICSharpTreeNode -->
+public interface ICSharpTreeNode : ITreeNode
+{
+  // Snipped for brevity
+}
+<!-- End ICSharpTreeNode -->
+```
+
+As long as the type is recognised from the list of types processed from the PSI assembly, it will be output. If the type is not recognised, an error is written to `stdout` and should be investigated.
+
+## Adding a new language
+
+To add a new language:
+
+* Add a new folder for the language
+* Run the PsiDocs2 app on the PSI assembly and output to this language folder
+* Do a manual clean up
+    * Combine index files that are too short, or don't have enough entries. E.g. the XML PSI doesn't have many nodes or navigators, so the index files have been combined into single files - `Navigators.md` and `TreeNodes.md`. Make sure to update the auto-index comment to reflect the starting letters of the entries in that file.
+    * Delete any empty files. If there are no utility classes, or element factories, delete the appropriate files (`Utils.md`, `ElementFactories.md`, etc.)
+* Annotate the index files. Manually edit the index files and add brief comments for each class. Make sure to add the text after the end HTML comment `<!-- End ICSharpTreeNode -->`
+* Add the `Overview.md` and `Manipulation.md` files to provide article style docs to provide an overview of the AST and how to manipulate the tree. The other files are intended to be reference files. See existing files for examples.
+* Add the files manually to `SUMMARY.md`
+
+## Updating a language
+
+When a new version of ReSharper is released, simply run PsiDocs2 and replace the existing content. Review the changes in a `git` tool. The changes are likely to be:
+
+* Changes to the type. Make sure the text content for that interface is still applicable.
+* Removed types. Update the index file to remove the section for that type, and update any references in non-index files, e.g. `Overview.md`
+* Added types. If the index files are auto-indexed (that is, the auto-index comment at the top of the file is still in place), the type will be added to the file, in the correct place alphabetically. If the index files are not auto-indexed (the auto-index comment has been removed), the type will be saved to a `-missing.md` file, where it can be manually copy-and-pasted to the appropriate file. Make sure to add a brief text section describing the type.
+
+## Editing tips
+
+* When manually creating a file such as `Overview.md`, types can be referenced simply by adding the HTML comments and running the PsiDocs2 app. This will update the file to contain the type definition.
+* The index files can be split across any number of files. If the app does not create an optimal balance of files vs number of entries per file, then the files can be manually edited. As long as the auto-index comment exists, and reflects the letters of the entries in that file, the app will update the new index files appropriately.
+* You can easily create index files ordered as you see fit by editing the auto-index comment to include the start and end index character for that file. For example, setting it to `<!-- auto-index A - Z` will include all items from A - Z.
+
+## Why disable auto-index?
+
+The auto-index scheme was added for the XML PSI, to allow for two indexes, one for the XML AST, and the other for the DTD AST. Since the types overlap in names, they can't be split alphabetically, so the indexes are maintained (semi-)manually. The auto-index comment is deleted, meaning the PsiDocs2 app will output any missing types to a separate file, where they can be manually moved to the appropriate file.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -167,6 +167,11 @@
     * Build scripts
     * XAML
     * XML Doc
+    * [Regular Expressions](PSI/Reference/RegExp/Overview.md)
+        * [Manipulating the Tree](PSI/Reference/RegExp/Manipulation.md)
+        * [Navigators](PSI/Reference/RegExp/Navigators.md)
+        * [Tree Nodes A-N](PSI/Reference/RegExp/TreeNodesA-N.md)
+        * [Tree Nodes O-Z](PSI/Reference/RegExp/TreeNodesO-Z.md)
 
 ## Part VI - Features
 * Analysis


### PR DESCRIPTION
Tracking PR for a branch looking at reference for the PSI trees. Picking off the easy ones first, to figure out a system so we can then tackle the bigger trees, such as C#. This is the regular expressions tree, and is based on the work for the [XML tree reference](https://www.jetbrains.com/resharper/devguide/PSI/Reference/Xml/Overview.html).

Likely to be lower priority than other areas that need documenting, especially when there are docs that are not yet up to date with ReSharper 9.