### PR TITLE
add format identifiers to all code blocks

### DIFF
--- a/topics/CustomLanguages/Parsing/Lexing/CsLex.md
+++ b/topics/CustomLanguages/Parsing/Lexing/CsLex.md
@@ -50,7 +50,7 @@ using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 
 The CsLex directives should be similar to the following:
 
-```
+```text
 %unicode
 
 %init{
@@ -104,7 +104,7 @@ Note the use of the `UNICODE_ZS` macro from the `Unicode.lex` file (see below), 
 
 The final section is a set of rules, which are defined by three things, a _state_, a _regular expression_ and an _action_. An example is:
 
-```
+```text
 <YYINITIAL> {WHITE_SPACE}  { return CssTokenType.WHITE_SPACE; }
 ```
 
@@ -118,7 +118,7 @@ Some actions might want to change the lexer state, which they can do with the `y
 
 The built-in ReSharper lexers tend to follow a slightly different pattern for the actions:
 
-```
+```text
 <YYINITIAL> {WHITE_SPACE}  { myCurrentTokenType = makeToken(CssTokenType.WHITE_SPACE); return myCurrentTokenType; }
 ```
 

--- a/topics/CustomLanguages/Parsing/Lexing/UtilityClasses.md
+++ b/topics/CustomLanguages/Parsing/Lexing/UtilityClasses.md
@@ -68,7 +68,7 @@ public partial class MyLexer
 
 And then in the [CsLex](CsLex.md) rules:
 
-```
+```text
 <YYINITIAL> {IDENTIFIER}   { return makeToken(FindKeywordByCurrentToken() ?? CSharpTokenType.IDENTIFIER); }
 ```
 

--- a/topics/HowTo/CreateMenuItemsUsingActions.md
+++ b/topics/HowTo/CreateMenuItemsUsingActions.md
@@ -6,7 +6,7 @@
 If you want to expose your feature in a menu or a toolbar, you should use actions. Action is a unit of work (implemented as a special class) that is associated with a particular menu or toolbar item. Note that you can assign a Visual Studio shortcut to an action. [Learn more about actions](Actions.md).
  
 Let's create a simple action that shows a message box being triggered.
-``` 
+```csharp 
     public abstract class SampleAction : IExecutableAction
     {
         public bool Update(IDataContext context, ActionPresentation presentation, DelegateUpdate nextUpdate)

--- a/topics/HowTo/TrackSolutionLoadingStatus.md
+++ b/topics/HowTo/TrackSolutionLoadingStatus.md
@@ -12,7 +12,7 @@ Sometimes, it is necessary for the plugin to begin its work only after the solut
  
 This example also demonstrates how the [ReSharper component model](ObtainComponentsInRuntime.md) can be used. Here the task is solved using one shell component and one solution component. For details, see the notes below.
 
-```
+```csharp
 [ShellComponent]
     public class SolutionStateTracker : ISolutionStateTracker
     {
@@ -75,21 +75,21 @@ This example also demonstrates how the [ReSharper component model](ObtainCompone
 * `SolutionStateNotifier` tracks solution status using the `ISolutionLoadTasksScheduler` object demanded via the constructor argument.
 * Once the solution is loaded, `SolutionStateNotifier` calls the particular method of the injected `SolutionStateTracker`, which, in turn, fires a signal.
 * `SolutionStateNotfier` also tracks solution closing:
-    ```
+    ```csharp
     lifetime.AddAction(solutionStateTracker.HandleSolutionClosed);
     ```
 * The `Lifetime.AddAction` method schedules an activity upon lifetime termination. As the lifetime for the `SolutionStateNotifier` is the same as the solution lifetime, the signal is called once the solution is going to close.
 * To use `SolutionStateTracker`, you should simply subscribe to a corresponding signal using the `Advise` method:
-    ```
+    ```csharp
     solutionStateTracker.AfterSolutionOpened.Advise(lifetime, () => {do somehting...});
     ```
     To obtain a `SolutionStateTracker` instance, you can, for example, get it from the current context (e.g., if you use it in an action):
-    ```
+    ```csharp
     var solutionStateTracker = context.GetComponent<SolutionStateTracker>();
 	solutionStateTracker.AfterSolutionOpened.Advise(lifetime, () => {do somehting...});
 	```
 	or demand it via the constructor argument of your component:
-    ```
+    ```csharp
     [SolutionComponent]
     public class MyClass
     {

--- a/topics/Products/InspectCode.md
+++ b/topics/Products/InspectCode.md
@@ -41,6 +41,6 @@ Currently, the only extension point for InspectCode that isn't part of ReSharper
 
 * Start InspectCode with following parameters
 
-  ```
+  ```powershell
   inspectcode ... /Plugin=path-to-custom-logger-dll
   ```

--- a/topics/Products/Rider.md
+++ b/topics/Products/Rider.md
@@ -36,7 +36,7 @@ This will provide MSBuild with an individual OBJ and BIN folder both the ReSharp
 
 Rider plugins are simple ZIP archives containing metadata about the plugin, ReSharper extensions (DLL) and/or IntelliJ extensions (JAR). The content is structured like this:
 
-```
+```text
 + plugin-root-folder
     + META-INF
         - plugin.xml

--- a/topics/basics/getting_started/plugin_template.md
+++ b/topics/basics/getting_started/plugin_template.md
@@ -10,11 +10,11 @@ The generator creates all the necessary project files based on a few template in
 Launch the <control>New Project</control> wizard via the <menupath>File | New | Project...</menupath> action and provide the following information:
 1. Download the [plugin template]() from the GitHub Release section.
 2. Install the plugin template by calling:
-```
+```powershell
 dotnet new --install JetBrains.ReSharper.SamplePlugin.*.nupkg
 ```
 3. Unpack the template with your preferred plugin name:
-```
+```powershell
 dotnet new resharper-rider-plugin --name MyPlugin
 ```
 > If your plugin should only target ReSharper, you can pass the `--resharper-only` switch.

--- a/topics/testing/Plugins_Testing.md
+++ b/topics/testing/Plugins_Testing.md
@@ -67,7 +67,7 @@ Input and output files involve special symbols and commands for indicating the s
 
 ReSharper adopts a convention-based approach to locating your tests. The convention suggests the following structure for the projects and the associated tests:
 
-```
+```text
 \src
   \your_project.sln
   \your_project_files

--- a/topics/testing/ProjectStructure.md
+++ b/topics/testing/ProjectStructure.md
@@ -14,7 +14,7 @@ The test project should also include a reference to the `JetBrains.ReSharper.SDK
 
 The standard project layout for a ReSharper project with tests is as follows:
 
-```
+```text
 +-- src\
 |   +-- {plugin}.sln
 |   +-- plugin\


### PR DESCRIPTION
Some code blocks were missing the formatting identifiers.
I.e. they looked like
``````text
``` 
some text
```
``````

instead of 
``````text
```text
some text
```
``````

which results in a rendering like:

![image](https://user-images.githubusercontent.com/349188/190992433-d2a4bced-9648-48a9-b4dc-1f8ab20f3a0a.png)

